### PR TITLE
Add TTS service with loader and audio player

### DIFF
--- a/story-reader/src/app/app.html
+++ b/story-reader/src/app/app.html
@@ -5,11 +5,18 @@
       type="text"
       class="form-control w-auto"
       [(ngModel)]="prompt"
-      placeholder="Describe your story"
+      placeholder="Enter text"
     />
-    <button class="btn btn-primary" (click)="generate()">Send</button>
+    <button class="btn btn-primary" (click)="generate()" [disabled]="loading">
+      <span
+        *ngIf="loading"
+        class="spinner-border spinner-border-sm me-2"
+        role="status"
+      ></span>
+      Send
+    </button>
   </div>
   <div *ngIf="audioUrl" class="mt-4">
-    <audio controls [src]="audioUrl" class="w-100"></audio>
+    <audio #player controls [src]="audioUrl" class="w-100"></audio>
   </div>
 </div>

--- a/story-reader/src/app/app.ts
+++ b/story-reader/src/app/app.ts
@@ -1,30 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { TtsService } from './tts.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, HttpClientModule],
   templateUrl: './app.html',
-  styleUrl: './app.css'
+  styleUrl: './app.css',
 })
 export class App {
   prompt = '';
   audioUrl?: string;
+  loading = false;
+  @ViewChild('player') audioRef?: ElementRef<HTMLAudioElement>;
+
+  constructor(private tts: TtsService) {}
 
   async generate() {
     if (!this.prompt) return;
+    this.loading = true;
+    this.audioUrl = undefined;
     try {
-      const response = await fetch('/api/story', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: this.prompt })
-      });
-      const blob = await response.blob();
+      const blob = await this.tts.synthesize(this.prompt).toPromise();
       this.audioUrl = URL.createObjectURL(blob);
+      setTimeout(() => {
+        if (this.audioRef?.nativeElement) {
+          this.audioRef.nativeElement.load();
+          this.audioRef.nativeElement.play();
+        }
+      });
     } catch (err) {
-      console.error('Failed to fetch story', err);
+      console.error('Failed to fetch audio', err);
+    } finally {
+      this.loading = false;
     }
   }
 }

--- a/story-reader/src/app/tts.service.ts
+++ b/story-reader/src/app/tts.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class TtsService {
+  constructor(private http: HttpClient) {}
+
+  synthesize(text: string): Observable<Blob> {
+    return this.http.post('/tts', { text }, { responseType: 'blob' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `TtsService` for calling the `/tts` backend endpoint
- show bootstrap spinner while waiting for the response
- play the returned audio once loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859e30e824483259f93c566c54c69c5