### PR TITLE
Add dark theme with starry background

### DIFF
--- a/story-reader/src/app/app.css
+++ b/story-reader/src/app/app.css
@@ -1,6 +1,16 @@
 
 .container {
-  margin-top: 50px;
+  margin-top: 20vh;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2rem;
+  border-radius: 8px;
+  backdrop-filter: blur(5px);
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+}
+
+h1 {
+  font-weight: 300;
+  text-shadow: 0 0 8px #ffffff;
 }
 
 

--- a/story-reader/src/index.html
+++ b/story-reader/src/index.html
@@ -8,7 +8,22 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
-<body>
+<body class="bg-dark text-light">
+  <div id="particles-js"></div>
   <app-root></app-root>
+  <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
+  <script>
+    particlesJS('particles-js', {
+      particles: {
+        number: { value: 60, density: { enable: true, value_area: 800 } },
+        color: { value: '#ffffff' },
+        shape: { type: 'circle' },
+        opacity: { value: 0.5, random: true },
+        size: { value: 2, random: true },
+        line_linked: { enable: false },
+        move: { enable: true, speed: 0.2 }
+      }
+    });
+  </script>
 </body>
 </html>

--- a/story-reader/src/styles.css
+++ b/story-reader/src/styles.css
@@ -1,8 +1,17 @@
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at bottom, #0d0d1a, #000);
+  color: #f1f1f1;
+  min-height: 100vh;
+  position: relative;
+}
+
+#particles-js {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
 }


### PR DESCRIPTION
## Summary
- make the index page dark and load a starry particle effect
- create a dark background gradient and container styling
- tune the app container with a blurred backdrop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b545ef4b48325beb8ff7759a3fb50