### PR TITLE
Implement moon phases and faster fireflies

### DIFF
--- a/story-reader/src/app/app.css
+++ b/story-reader/src/app/app.css
@@ -7,6 +7,11 @@
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
+#story-container {
+  margin-top: 0;
+  transform: translateY(-20%);
+}
+
 #particles-js {
   position: fixed;
   width: 100%;
@@ -30,8 +35,32 @@
   top: 5%;
   left: 5%;
   width: 100px;
+  height: 100px;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBkPSJNNTAgNWE0NSA0NSAwIDEgMCAwIDkwIDMwIDQ1IDAgMSAxIDAtOTB6IiBmaWxsPSIjZmZkMjdmIi8+PC9zdmc+Cg==");
+  background-size: cover;
+  border-radius: 50%;
+  overflow: hidden;
   pointer-events: none;
   z-index: -1;
+}
+
+#moon .shadow {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: #0b0b12;
+  transform: translateX(-100%);
+  animation: moonPhase 10s linear infinite;
+}
+
+@keyframes moonPhase {
+  0%, 100% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(-50%);
+  }
 }
 
 input.form-control {

--- a/story-reader/src/app/app.html
+++ b/story-reader/src/app/app.html
@@ -1,7 +1,7 @@
-<img id="moon" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBkPSJNNTAgNWE0NSA0NSAwIDEgMCAwIDkwIDMwIDQ1IDAgMSAxIDAtOTB6IiBmaWxsPSIjZmZkMjdmIi8+PC9zdmc+Cg==" />
+<div id="moon"><div class="shadow"></div></div>
 <div id="particles-js"></div>
 <div id="fireflies-js"></div>
-<div class="container text-center mt-5">
+<div id="story-container" class="container text-center mt-5">
   <h1 class="mb-4">Bedtime Story Reader</h1>
   <div class="input-group justify-content-center mb-3">
     <input

--- a/story-reader/src/app/app.ts
+++ b/story-reader/src/app/app.ts
@@ -18,7 +18,6 @@ export class App implements AfterViewInit {
   audioUrl?: string;
   loading = false;
   @ViewChild('player') audioRef?: ElementRef<HTMLAudioElement>;
-  @ViewChild('moon', { static: true }) moonRef?: ElementRef<HTMLImageElement>;
 
   constructor(private tts: TtsService, private particles: ParticleService) {}
 

--- a/story-reader/src/app/particle.service.ts
+++ b/story-reader/src/app/particle.service.ts
@@ -50,14 +50,14 @@ export class ParticleService {
             anim: { enable: true, speed: 1, size_min: 1, sync: false },
           },
           line_linked: { enable: false },
-          move: {
-            enable: true,
-            speed: 1,
-            direction: 'none',
-            random: false,
-            straight: true,
-            out_mode: 'out',
-          },
+            move: {
+              enable: true,
+              speed: 2,
+              direction: 'none',
+              random: false,
+              straight: true,
+              out_mode: 'out',
+            },
         },
         retina_detect: true,
       });


### PR DESCRIPTION
## Summary
- tweak particle service to make fireflies move faster
- animate the moon from full to half phase
- shift the main story block slightly above the center
- clean up unused moon reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c18b851ac8325af85ee7ba3dcad2b