### PR TITLE
Refine moon and firefly animations

### DIFF
--- a/story-reader/src/app/app.css
+++ b/story-reader/src/app/app.css
@@ -50,16 +50,16 @@
   height: 100%;
   border-radius: 50%;
   background-color: #0b0b12;
-  transform: translateX(-100%);
-  animation: moonPhase 10s linear infinite;
+  transform: translateX(100%);
+  animation: moonPhase 30s linear infinite;
 }
 
 @keyframes moonPhase {
   0%, 100% {
-    transform: translateX(-100%);
+    transform: translateX(100%);
   }
   50% {
-    transform: translateX(-50%);
+    transform: translateX(50%);
   }
 }
 

--- a/story-reader/src/app/particle.service.ts
+++ b/story-reader/src/app/particle.service.ts
@@ -33,16 +33,16 @@ export class ParticleService {
       retina_detect: true,
     });
 
-    // Firefly layer - gentle blinking fireflies
+    // Firefly layer - blinking fireflies with dynamic movement
     if (fireflyId) {
       particlesJS(fireflyId, {
         particles: {
           number: { value: 2, density: { enable: true, value_area: 800 } },
-          color: { value: '#ccff55' },
+          color: { value: '#ffd166' },
           shape: { type: 'circle' },
           opacity: {
             value: 1,
-            anim: { enable: true, speed: 0.2, opacity_min: 0, sync: false },
+            anim: { enable: true, speed: 0.5, opacity_min: 0, sync: false },
           },
           size: {
             value: 4,
@@ -50,17 +50,25 @@ export class ParticleService {
             anim: { enable: true, speed: 1, size_min: 1, sync: false },
           },
           line_linked: { enable: false },
-            move: {
-              enable: true,
-              speed: 2,
-              direction: 'none',
-              random: false,
-              straight: true,
-              out_mode: 'out',
-            },
+          move: {
+            enable: true,
+            speed: 3,
+            direction: 'none',
+            random: true,
+            straight: false,
+            out_mode: 'out',
+          },
         },
         retina_detect: true,
       });
+
+      // Periodically change speed to mimic erratic firefly movement
+      setInterval(() => {
+        const instance = (window as any).pJSDom?.find((p: any) => p?.pJS?.canvas?.el?.id === fireflyId)?.pJS;
+        if (instance) {
+          instance.particles.move.speed = 1 + Math.random() * 4; // between 1 and 5
+        }
+      }, 2000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- adjust the moon phase animation to move from the right and slow it down
- tint fireflies more yellow and give them dynamic movement speed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1a5393dc8325929105ce9b3f1abf