### PR TITLE
Add story generator UI

### DIFF
--- a/story-reader/src/app/app.css
+++ b/story-reader/src/app/app.css
@@ -119,4 +119,14 @@ h1 {
   padding: 0 2px;
 }
 
+.animated-story {
+  white-space: pre-line;
+  animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 

--- a/story-reader/src/app/app.html
+++ b/story-reader/src/app/app.html
@@ -8,7 +8,7 @@
       type="text"
       class="form-control w-auto"
       [(ngModel)]="prompt"
-      placeholder="Enter your bedtime story prompt"
+      placeholder="Enter theme for your bedtime story"
     />
     <button class="btn btn-primary" (click)="generate()" [disabled]="loading">
       <span
@@ -16,9 +16,13 @@
         class="spinner-border spinner-border-sm me-2"
         role="status"
       ></span>
-      Read
+      Generate
     </button>
   </div>
+
+  <div *ngIf="displayedStory" class="text-display animated-story">{{ displayedStory }}</div>
+  <button *ngIf="story" class="btn btn-secondary mt-3" (click)="playStory()" [disabled]="loading">Play Audio</button>
+
   <div *ngIf="audioUrl" class="mt-4">
     <div class="audio-container">
       <audio
@@ -35,8 +39,23 @@
       <span
         *ngFor="let word of words; let i = index"
         [class.highlight]="i === currentWordIndex"
-        >{{ word }} </span
+      >{{ word }} </span
       >
+    </div>
+  </div>
+  <button class="btn btn-info mt-3" data-bs-toggle="modal" data-bs-target="#cloneModal">Clone</button>
+</div>
+
+<!-- Clone Modal -->
+<div class="modal fade" id="cloneModal" tabindex="-1" aria-labelledby="cloneModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="cloneModalLabel">Clone</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+      </div>
     </div>
   </div>
 </div>

--- a/story-reader/src/app/story.service.ts
+++ b/story-reader/src/app/story.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class StoryService {
+  constructor(private http: HttpClient) {}
+
+  generateStory(theme: string): Observable<{ story: string }> {
+    return this.http.post<{ story: string }>('/generate-story', { theme });
+  }
+}

--- a/story-reader/src/index.html
+++ b/story-reader/src/index.html
@@ -13,5 +13,6 @@
 <body>
   <app-root></app-root>
   <script src="https://cdn.jsdelivr.net/npm/plyr@3.7.8/dist/plyr.polyfilled.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- call `/generate-story` from a new `StoryService`
- reveal generated stories with a typing effect
- add a button to play audio of the generated story via `/tts`
- insert an empty clone modal and include Bootstrap JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869c2fef6a88325bdbc70f15a1dc7ea