### PR TITLE
Fix highlight update during audio playback

### DIFF
--- a/story-reader/src/app/audio-player.html
+++ b/story-reader/src/app/audio-player.html
@@ -4,7 +4,5 @@
     controls
     [src]="src"
     class="w-100"
-    (timeupdate)="timeUpdate.emit($event)"
-    (ended)="ended.emit($event)"
   ></audio>
 </div>

--- a/story-reader/src/app/audio-player.ts
+++ b/story-reader/src/app/audio-player.ts
@@ -18,8 +18,13 @@ export class AudioPlayer implements AfterViewInit {
   private player?: any;
 
   ngAfterViewInit() {
-    if (this.audioRef?.nativeElement && typeof Plyr !== 'undefined') {
-      this.player = new Plyr(this.audioRef.nativeElement, {
+    const audioEl = this.audioRef?.nativeElement;
+    if (audioEl) {
+      audioEl.addEventListener('timeupdate', (ev) => this.timeUpdate.emit(ev));
+      audioEl.addEventListener('ended', (ev) => this.ended.emit(ev));
+    }
+    if (audioEl && typeof Plyr !== 'undefined') {
+      this.player = new Plyr(audioEl, {
         controls: ['play', 'progress', 'current-time', 'mute', 'volume']
       });
       if (this.src) {


### PR DESCRIPTION
## Summary
- rewire timeupdate handling in `AudioPlayer`
- remove `(timeupdate)` and `(ended)` from audio-player template to rely on programmatic listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0c04a9a48325950e8e5c35756902